### PR TITLE
Bump Ubuntu version in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']


### PR DESCRIPTION
https://github.com/kmaehashi/flake8-force/actions/runs/14340540491
```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```